### PR TITLE
don't render menu if item is no longer valid.

### DIFF
--- a/admin-cleanup.php
+++ b/admin-cleanup.php
@@ -132,6 +132,9 @@ class Admin_Cleanup
                 }else{
                     $group = 'admin-cleanup-' . $val;
                 }
+                // is menue item still valid?
+                if( empty( $this->menu[ $key ] ) ){ continue;}
+
                 $the_menu = $this->menu[ $key ];
                 $the_href = menu_page_url( $the_menu[2], false );
                 $the_href = empty( $the_href ) ? $the_menu[2] : $the_href;


### PR DESCRIPTION
if a menu item is no longer valid, i.e. deactivated plugin. skip over and move along.
